### PR TITLE
修正连续多次点击翻页之后会翻到空白页面里

### DIFF
--- a/EHenTaiViewer/QJMangaViewController.m
+++ b/EHenTaiViewer/QJMangaViewController.m
@@ -139,20 +139,22 @@
 }
 
 - (void)forwardPage {
-    CGPoint currOffsize = self.collectionView.contentOffset;
-    currOffsize.x -= UIScreenWidth();
-    if (currOffsize.x >= 0) {
-        [self.collectionView setContentOffset:currOffsize animated:YES];
-        self.view.userInteractionEnabled = NO;
+    NSIndexPath *indexNow=[self.collectionView indexPathForCell:[self.collectionView visibleCells][0]];
+    if (indexNow.item >= 1) {
+        NSIndexPath *indexPrev=[NSIndexPath indexPathForItem:indexNow.item-1 inSection:indexNow.section];
+        [self.collectionView scrollToItemAtIndexPath:indexPrev atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally animated:YES];
+    } else {
+        [self show];
     }
 }
 
 - (void)nextPage {
-    CGPoint currOffsize = self.collectionView.contentOffset;
-    currOffsize.x += UIScreenWidth();
-    if (currOffsize.x <= UIScreenWidth() * (self.items.count - 1)) {
-        [self.collectionView setContentOffset:currOffsize animated:YES];
-        self.view.userInteractionEnabled = NO;
+    NSIndexPath *indexNow=[self.collectionView indexPathForCell:[self.collectionView visibleCells][0]];
+    if (indexNow.item <= self.items.count-2) {
+        NSIndexPath *indexNext=[NSIndexPath indexPathForItem:indexNow.item+1 inSection:indexNow.section];
+        [self.collectionView scrollToItemAtIndexPath:indexNext atScrollPosition:UICollectionViewScrollPositionCenteredHorizontally animated:YES];
+    } else {
+        [self show];
     }
 }
 


### PR DESCRIPTION
原翻页方案会在连续多次点击翻页之后（大约翻5页），接下来的那页不会被正确加载。
由于是 `cell` 没有被正确加载，导致 `webview` 不显示，点击与常压手势操作也都会失效。

修改点击翻页操作为 `UICollectionView scrollToItemAtIndexPath:`，
当无页可翻时，显示顶栏与底栏。